### PR TITLE
Review CLI release workflow

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -34,6 +34,12 @@ runs:
         restore-keys: |
           konan-${{ runner.os }}-${{ inputs.tasks }}-
           konan-${{ runner.os }}-
+    - name: Print out cache contents
+      shell: bash
+      run: |
+        echo "::group::Konan cache contents"
+        ls -lR ~/.konan/ || echo "Empty"
+        echo "::endgroup::"
     - name: Run Gradle tasks
       shell: bash
       run: |

--- a/.github/steps/fetch-actual-tag.sh
+++ b/.github/steps/fetch-actual-tag.sh
@@ -10,6 +10,5 @@ set -euo pipefail
 
 tag_name=${1:?Tag name expected}
 
-echo "TAG_NAME=$tag_name"
-echo "TAG_SUBJECT=$(git tag --list --format='%(contents:subject)' $tag_name)"
-echo "TAG_BODY=$(git tag --list --format='%(contents:body)' $tag_name)"
+git update-ref -d "refs/heads/$tag_name" || true
+git fetch -f origin "refs/tags/$tag_name:refs/tags/$tag_name"

--- a/.github/steps/parse-tag-info.sh
+++ b/.github/steps/parse-tag-info.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 Gabriel Feo
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -euo pipefail
+
+tag_name=${1:?Tag name expected}
+
+echo "TAG_NAME=$tag_name"
+echo "TAG_SUBJECT=$(git tag --list --format='%(contents:subject)' $tag_name)"
+echo "TAG_BODY=$(git tag --list --format='%(contents:body)' $tag_name)"

--- a/.github/steps/parse-tag-message.sh
+++ b/.github/steps/parse-tag-message.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 Gabriel Feo
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -euo pipefail
+
+tag_name=${1:?Tag name expected}
+
+subject="$(git tag --list --format='%(contents:subject)' "$tag_name")"
+body="$(git tag --list --format='%(contents:body)' "$tag_name")"
+echo -e "$subject\n\n$body"

--- a/.github/steps/require-annotated-tag.sh
+++ b/.github/steps/require-annotated-tag.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 Gabriel Feo
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -euo pipefail
+
+tag_name=${1:?Tag name expected}
+
+tag_ref="$(git cat-file -t "$tag_name")"
+if [[ "$tag_ref" != "tag" ]]; then
+  echo "Tag $tag_name isn't annotated: $tag_ref"
+  exit 1
+fi

--- a/.github/steps/update-homebrew-formula.py
+++ b/.github/steps/update-homebrew-formula.py
@@ -7,11 +7,11 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.        
 
 import argparse
-from collections import namedtuple
 import hashlib
 import os
 import requests
 import sys
+from collections import namedtuple
 
 TAP_REPOSITORY = 'gabrielfeo/homebrew-50-72'
 
@@ -63,6 +63,7 @@ response = requests.post(
 
 if response.status_code in range(200, 299):
     print(f"Trigger successful: {response.status_code}")
+    print(f"See it on https://github.com/{TAP_REPOSITORY}")
 else:
     print(f"Request failed: {response.status_code}\n{response.content}", file=sys.stderr)
     exit(1)

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -16,20 +16,6 @@ defaults:
 
 jobs:
 
-  parse-tag:
-    runs-on: ubuntu-latest
-    env:
-      TAG_NAME: ${{ github.ref_name }}
-    outputs:
-      name: ${{ env.TAG_NAME }}
-      subject: ${{ env.TAG_SUBJECT }}
-      body: ${{ env.TAG_BODY }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Parse tag info
-        run: ./.github/steps/parse-tag-info.sh "${{ env.TAG_NAME }}" >> "$GITHUB_ENV"
-
   package-linux-release:
     runs-on: ubuntu-latest
     outputs:
@@ -57,16 +43,23 @@ jobs:
           path-to-upload: 'cli/build/release/**'
 
   create-release:
-    needs: [parse-tag, package-linux-release, package-macos-release]
+    needs: [package-linux-release, package-macos-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       GITHUB_USERNAME: 'gabrielfeo'
       GITHUB_TOKEN: ${{ secrets.CROSS_REPO_GITHUB_TOKEN }}
+      TAG_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Fetch actual tag
+        run: .github/steps/fetch-actual-tag.sh "$TAG_NAME"
+      - name: Require annotated tag
+        run: .github/steps/require-annotated-tag.sh "$TAG_NAME"
+      - name: Parse tag message
+        run: ./.github/steps/parse-tag-message.sh "$TAG_NAME" | tee ./tag_message
       - name: Download artifacts
         uses: actions/download-artifact@v3.0.0
         with:
@@ -74,13 +67,10 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v0.1.14
         with:
-          tag_name: ${{ needs.parse-tag.outputs.name }}
+          tag_name: ${{ env.TAG_NAME }}
           target_commitish: ${{ github.sha }}
           draft: true
-          body: |
-            ${{ needs.parse-tag.outputs.subject }}
-
-            ${{ needs.parse-tag.outputs.body }}
+          body_path: ./tag_message
           fail_on_unmatched_files: true
           files: |
             artifacts/linux/*
@@ -88,6 +78,6 @@ jobs:
       - name: Update Homebrew formula
         run: |
           .github/steps/update-homebrew-formula.py \
-            --version "${{ needs.parse-tag.outputs.name }}" \
+            --version "$TAG_NAME" \
             --trigger-source "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --assets artifacts/linux/* artifacts/macos/*

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -8,20 +8,27 @@ name: 'CLI release'
 
 on:
   push:
-    branches: [main]
-  workflow_dispatch:
-    inputs:
-      do-create-release:
-        description: 'Create release?'
-        type: boolean
-        required: false
-        default: false
+    tags: [v*]
 
 defaults:
   run:
     shell: bash
 
 jobs:
+
+  parse-tag:
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.ref_name }}
+    outputs:
+      name: ${{ env.TAG_NAME }}
+      subject: ${{ env.TAG_SUBJECT }}
+      body: ${{ env.TAG_BODY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Parse tag info
+        run: ./.github/steps/parse-tag-info.sh "${{ env.TAG_NAME }}" >> "$GITHUB_ENV"
 
   package-linux-release:
     runs-on: ubuntu-latest
@@ -36,11 +43,6 @@ jobs:
           artifact-name: 'linux'
           tasks: ':cli:packageReleaseLinuxX64'
           path-to-upload: 'cli/build/release/**'
-      - name: Parse version number
-        run: |
-          VERSION="$(ls ./cli/build/release/*.zip | head -1 | grep -Eo 'v[0-9.]+')"
-          echo "Parsed version $VERSION"
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
   package-macos-release:
     runs-on: macos-latest
@@ -55,8 +57,7 @@ jobs:
           path-to-upload: 'cli/build/release/**'
 
   create-release:
-    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.do-create-release }}
-    needs: [package-linux-release, package-macos-release]
+    needs: [parse-tag, package-linux-release, package-macos-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -73,10 +74,13 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v0.1.14
         with:
-          tag_name: ${{ needs.package-linux-release.outputs.version }}
+          tag_name: ${{ needs.parse-tag.outputs.name }}
           target_commitish: ${{ github.sha }}
           draft: true
-          generate_release_notes: true
+          body: |
+            ${{ needs.parse-tag.outputs.subject }}
+
+            ${{ needs.parse-tag.outputs.body }}
           fail_on_unmatched_files: true
           files: |
             artifacts/linux/*
@@ -84,6 +88,6 @@ jobs:
       - name: Update Homebrew formula
         run: |
           .github/steps/update-homebrew-formula.py \
-            --version "${{ needs.package-linux-release.outputs.version }}" \
+            --version "${{ needs.parse-tag.outputs.name }}" \
             --trigger-source "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --assets artifacts/linux/* artifacts/macos/*

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -51,6 +51,7 @@ jobs:
       GITHUB_USERNAME: 'gabrielfeo'
       GITHUB_TOKEN: ${{ secrets.CROSS_REPO_GITHUB_TOKEN }}
       TAG_NAME: ${{ github.ref_name }}
+      ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -79,5 +80,5 @@ jobs:
         run: |
           .github/steps/update-homebrew-formula.py \
             --version "$TAG_NAME" \
-            --trigger-source "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --trigger-source "$ACTION_RUN_URL" \
             --assets artifacts/linux/* artifacts/macos/*

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,3 +31,19 @@ jobs:
         uses: ./.github/actions/build
         with:
           tasks: 'check'
+
+  check-shell-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get changed files
+        id: diff
+        uses: tj-actions/changed-files@v18.6
+        with:
+          files: '**/*.sh'
+      - name: shellcheck
+        if: ${{ steps.diff.outputs.any_modified }}
+        uses: docker://koalaman/shellcheck:latest
+        with:
+          args: ${{ steps.diff.outputs.all_modified_files }}

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Release based on annotated tags

>Fetching the tag again is a workaround for actions/checkout#290.

Do shellcheck on PRs

Print out Konan cache contents for debugging

>https://github.com/gabrielfeo/50-72/runs/5770512043?check_suite_focus=true#step:3:179
>Cache is unstable in macOS.

Print tap repo URL after formula update trigger