### PR TITLE
Don't fail on squash messages

### DIFF
--- a/build-src/src/main/kotlin/multiplatform-js-browser-app.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-js-browser-app.gradle.kts
@@ -7,7 +7,7 @@
  */        
 
 plugins {
-    kotlin("multiplatform")
+    id("multiplatform")
 }
 
 configureJsTarget {

--- a/build-src/src/main/kotlin/multiplatform-js-browser-library.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-js-browser-library.gradle.kts
@@ -7,7 +7,7 @@
  */        
 
 plugins {
-    kotlin("multiplatform")
+    id("multiplatform")
 }
 
 configureJsTarget {

--- a/build-src/src/main/kotlin/multiplatform-native-app-release.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-native-app-release.gradle.kts
@@ -6,27 +6,28 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */        
 
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
 plugins {
     id("multiplatform-native-app")
 }
 
-val packageRelease by tasks.registering(Zip::class) {
+val packageRelease by tasks.registering(Zip::class) task@{
     group = "Release"
 }
 
 kotlin.targets.configureEach {
-    if ("metadata" in name) {
+    if (platformType != KotlinPlatformType.native) {
         return@configureEach
     }
-    val targetRelease = createPackageTaskFor(this)
+    val targetRelease = registerPackageTaskFor(this)
     packageRelease.configure {
         dependsOn(targetRelease)
     }
 }
 
-fun createPackageTaskFor(target: KotlinTarget): TaskProvider<Zip> {
+fun registerPackageTaskFor(target: KotlinTarget): TaskProvider<Zip> {
     val suffix = target.name.capitalize()
     return tasks.register<Zip>("packageRelease$suffix") {
         val executableLinkage = tasks.named("linkReleaseExecutable$suffix")

--- a/build-src/src/main/kotlin/multiplatform-native-app.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-native-app.gradle.kts
@@ -7,7 +7,7 @@
  */        
 
 plugins {
-    kotlin("multiplatform")
+    id("multiplatform")
 }
 
 configureNativeTargets {

--- a/build-src/src/main/kotlin/multiplatform-native-library.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-native-library.gradle.kts
@@ -7,7 +7,7 @@
  */        
 
 plugins {
-    kotlin("multiplatform")
+    id("multiplatform")
 }
 
 configureNativeTargets {

--- a/build-src/src/main/kotlin/multiplatform.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform.gradle.kts
@@ -1,0 +1,24 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/*
+ * Copyright (c) 2022 Gabriel Feo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+plugins {
+    kotlin("multiplatform")
+}
+
+
+configure<KotlinMultiplatformExtension> {
+    // Use locally better debugging support
+    if (shouldEnableJvmTarget()) {
+        jvm()
+    }
+}
+
+fun Project.shouldEnableJvmTarget(): Boolean =
+    providers.gradleProperty("com.gabrielfeo.5072.jvmTarget").isPresent

--- a/build-src/src/main/kotlin/multiplatform.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform.gradle.kts
@@ -20,5 +20,16 @@ configure<KotlinMultiplatformExtension> {
     }
 }
 
+if (shouldShowTestStandardStreams()) {
+    tasks.withType<Test>().configureEach {
+        testLogging {
+            showStandardStreams = true
+        }
+    }
+}
+
 fun Project.shouldEnableJvmTarget(): Boolean =
-    providers.gradleProperty("com.gabrielfeo.5072.jvmTarget").isPresent
+    providers.gradleProperty("com.gabrielfeo.5072.jvmTarget").orNull?.toBoolean() ?: false
+
+fun Project.shouldShowTestStandardStreams(): Boolean =
+    providers.gradleProperty("com.gabrielfeo.5072.showTestStandardStreams").orNull?.toBoolean() ?: false

--- a/formatter/src/commonTest/kotlin/FormatFullMessageTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatFullMessageTest.kt
@@ -95,11 +95,37 @@ class FormatFullMessageTest {
         assertEquals(MESSAGE_73_WITH_COMMENTS_FIXED, reformatted)
     }
 
+    /**
+     * Git ignores any empty lines before the subject line, so it shouldn't be considered
+     * for formatting or validation. Auto-generated squash messages are a case of this.
+     */
+    @Test
+    fun stripsCommentsAndEmptyLinesBeforeSubject() {
+        val reformatted = formatFullMessage(SQUASH_MESSAGE_SUBJECT_50_BODY_72)
+        assertEquals(SQUASH_MESSAGE_SUBJECT_50_BODY_72_STRIPPED, reformatted)
+    }
+
     @Test
     fun reformatsMiscMessages() {
-        miscMessages.onEachIndexed { i, (original, expected) ->
-            val actual = formatFullMessage(original)
-            assertEquals(expected, actual, "Failed at case $i")
+        for ((i, case) in miscMessages.iterator().withIndex()) {
+            val (original, expected) = case
+            try {
+                val actual = formatFullMessage(original)
+                assertEquals(expected, actual, "Message differs at case $i")
+            } catch (error: Throwable) {
+                throw AssertionError("Exception thrown at case $i: ${error.stackTraceToString()}")
+            }
+        }
+    }
+
+    @Test
+    fun reformatsMiscInvalidMessages() {
+        for ((i, case) in miscInvalidMessages.iterator().withIndex()) {
+            val (original, expectedErrorMessage) = case
+            val error = assertFails {
+                formatFullMessage(original)
+            }
+            assertEquals(expectedErrorMessage, error.message, "Error message differs at case $i")
         }
     }
 }

--- a/formatter/src/commonTest/kotlin/Messages.kt
+++ b/formatter/src/commonTest/kotlin/Messages.kt
@@ -126,8 +126,40 @@ const val SUBJECT_50_BODY_73_TWO_PARAGRAPHS_DOUBLE_NEWLINE_FIXED = """$SINGLE_LI
 
 $BODY_73_TWO_PARAGRAPHS_DOUBLE_NEWLINE_FIXED"""
 
+const val SQUASH_MESSAGE_SUBJECT_50_BODY_72 = """# This is a combination of 2 commits.
+# This is the 1st commit message:
+
+a
+
+# This is the commit message #2:
+
+b
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# Date:      Fri Apr 1 11:21:10 2022 +0100
+#
+# interactive rebase in progress; onto 11e86f9
+# Last commands done (2 commands done):
+#    pick 019360b a
+#    squash c442edd b
+# No commands remaining.
+# You are currently rebasing branch 'fix/error-on-squash-messages' on '11e86f9'.
+#
+# Changes to be committed:
+#	new file:   a
+#	new file:   b
+#
+"""
+
+const val SQUASH_MESSAGE_SUBJECT_50_BODY_72_STRIPPED = """a
+
+
+b """
 
 val miscMessages = mapOf(
+    //0------------------------------------------------------------------
     """
     $SINGLE_LINE_50
     
@@ -142,7 +174,7 @@ val miscMessages = mapOf(
         foo foo foo foo ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum
         ipsum ipsum ipsum ipsum ipsum ipsum
         """.trimIndent(),
-    //------------------------------------------------------------------
+    //1------------------------------------------------------------------
     """
     $SINGLE_LINE_50
     
@@ -157,7 +189,7 @@ val miscMessages = mapOf(
         foo foo foo foo foo foo foo ipsum ipsum ipsum ipsum ipsum ipsum ipsum
         ipsum ipsum ipsum ipsum ipsum ipsum ipsum ipsum
         """.trimIndent(),
-    //------------------------------------------------------------------
+    //2------------------------------------------------------------------
     """
     $SINGLE_LINE_50
     
@@ -168,7 +200,7 @@ val miscMessages = mapOf(
         
         foo
         """.trimIndent(),
-    //------------------------------------------------------------------
+    //3------------------------------------------------------------------
     """
     $SINGLE_LINE_50
     
@@ -179,7 +211,77 @@ val miscMessages = mapOf(
         
         foo
         """.trimIndent(),
-    //------------------------------------------------------------------
+    //4------------------------------------------------------------------
+    """
+    # This is a combination of 2 commits.
+    # This is the 1st commit message:
+    
+    a
+    
+    # This is the commit message #2:
+    
+    $SINGLE_LINE_51
+    
+    # Please enter the commit message for your changes. Lines starting
+    # with '#' will be ignored, and an empty message aborts the commit.
+    #
+    # Date:      Fri Apr 1 11:21:10 2022 +0100
+    #
+    # interactive rebase in progress; onto 11e86f9
+    # Last commands done (2 commands done):
+    #    pick 019360b a
+    #    squash c442edd b
+    # No commands remaining.
+    # You are currently rebasing branch 'fix/error-on-squash-messages' on '11e86f9'.
+    #
+    # Changes to be committed:
+    #	new file:   a
+    #	new file:   b
+    #
+    """.trimIndent() to """
+        a
+        
+        
+        $SINGLE_LINE_51 
+        """.trimIndent(),
+    //5------------------------------------------------------------------
+    """
+    |# This is a combination of 2 commits.
+    |# This is the 1st commit message:
+    |
+    |a
+    |
+    |$SINGLE_LINE_51
+    |
+    |# This is the commit message #2:
+    |
+    |${BODY_73.lines().joinToString("\n|")}
+    |
+    |# Please enter the commit message for your changes. Lines starting
+    |# with '#' will be ignored, and an empty message aborts the commit.
+    |#
+    |# Date:      Fri Apr 1 11:21:10 2022 +0100
+    |#
+    |# interactive rebase in progress; onto 11e86f9
+    |# Last commands done (2 commands done):
+    |#    pick 019360b a
+    |#    squash c442edd b
+    |# No commands remaining.
+    |# You are currently rebasing branch 'fix/error-on-squash-messages' on '11e86f9'.
+    |#
+    |# Changes to be committed:
+    |#	new file:   a
+    |#	new file:   b
+    |#
+    """.trimMargin() to """
+        |a
+        |
+        |$SINGLE_LINE_51
+        |
+        |
+        |${BODY_73_FIXED.lines().joinToString("\n|")} 
+        """.trimMargin(),
+    //6------------------------------------------------------------------
     """
     $SINGLE_LINE_50
     
@@ -304,7 +406,7 @@ val miscMessages = mapOf(
         long long long long long long long long long long long long long long
         long
         """.trimIndent(),
-    //------------------------------------------------------------------
+    //7------------------------------------------------------------------
     """
     $SINGLE_LINE_50
     
@@ -374,4 +476,36 @@ val miscMessages = mapOf(
         long long long long long long long long long long long long long long
         long
         """.trimIndent(),
+)
+
+val miscInvalidMessages = mapOf(
+    //1------------------------------------------------------------------
+    """
+    # This is a combination of 2 commits.
+    # This is the 1st commit message:
+    
+    $SINGLE_LINE_51
+    
+    # This is the commit message #2:
+    
+    b
+    
+    # Please enter the commit message for your changes. Lines starting
+    # with '#' will be ignored, and an empty message aborts the commit.
+    #
+    # Date:      Fri Apr 1 11:21:10 2022 +0100
+    #
+    # interactive rebase in progress; onto 11e86f9
+    # Last commands done (2 commands done):
+    #    pick 019360b a
+    #    squash c442edd b
+    # No commands remaining.
+    # You are currently rebasing branch 'fix/error-on-squash-messages' on '11e86f9'.
+    #
+    # Changes to be committed:
+    #	new file:   a
+    #	new file:   b
+    #
+    """.trimIndent() to
+        HEADING_OVER_50_MESSAGE
 )


### PR DESCRIPTION
Don't fail on squash messages by stripping comments and blank lines
before subject during formatting.

Hook would fail rebases on squash steps with "There must be a blank line
between subject and body", because the formatter impl. would always
think the first line is the subject. On auto-generated squash messages,
the 3 first lines are 2 comments and 1 blank line. They're all ignored
by git, so they should be ignored by the formatter.

Resolves #8.

#### Other changes

- Enable the JVM target conditionally for better debugging support
- Show test stdout conditionally

Editing the build-src to add them occasionally invalidates a lot of
classpaths causing a slower build.
