### PR TITLE
Fix CLI usage errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ hook         Install the 50-72 git hook in the current repository.
   </summary>
 
   `50-72 hook --install` simply adds to the
-  [`prepare-commit-msg` git hook][man-githook]
+  [`commit-msg` git hook][man-githook]
   of the repository you run it from. If you already have such a hook in that repo, it will append to it,
   otherwise it will create one. 
 
@@ -190,6 +190,6 @@ The project is written in Kotlin Multiplatform compiling to native code and Java
 [rule-about]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [brew]: https://brew.sh/
 [releases]: https://github.com/gabrielfeo/50-72/releases
-[man-githook]: https://git-scm.com/docs/githooks#_prepare_commit_msg
+[man-githook]: https://git-scm.com/docs/githooks#_commit_msg
 [issues]: https://github.com/gabrielfeo/50-72/issues
 [new-issue]: https://github.com/gabrielfeo/50-72/issues/new

--- a/cli/src/commonMain/kotlin/cli/command/FormatMessage.kt
+++ b/cli/src/commonMain/kotlin/cli/command/FormatMessage.kt
@@ -9,7 +9,7 @@
 package cli.command
 
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -39,7 +39,7 @@ class FormatMessage(
             val formattedMessage = format(message, isMarkdown)
             echo(formattedMessage)
         } catch (error: IllegalArgumentException) {
-            throw UsageError(error.message.orEmpty(), paramName = "message")
+            throw PrintMessage(error.message.orEmpty(), error = true)
         }
     }
 }

--- a/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
@@ -12,7 +12,7 @@ import cli.commons.defaultFileSystem
 import cli.commons.readText
 import cli.commons.writeText
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.default
 import formatFullMessage
@@ -41,7 +41,7 @@ class FormatFile(
             val formattedContent = format(content, false)
             file.writeText(formattedContent, fileSystem)
         } catch (error: IllegalArgumentException) {
-            throw UsageError(error.message.orEmpty(), paramName = "file")
+            throw PrintMessage(error.message.orEmpty(), error = true)
         }
     }
 }

--- a/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
@@ -12,6 +12,7 @@ import cli.commons.defaultFileSystem
 import cli.commons.readText
 import cli.commons.writeText
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.default
 import formatFullMessage
@@ -34,9 +35,13 @@ class FormatFile(
     ).default(DEFAULT_GIT_MSG_FILE)
 
     override fun run() {
-        val file = messageFile.toPath()
-        val content = file.readText(fileSystem)
-        val formattedContent = format(content, false)
-        file.writeText(formattedContent, fileSystem)
+        try {
+            val file = messageFile.toPath()
+            val content = file.readText(fileSystem)
+            val formattedContent = format(content, false)
+            file.writeText(formattedContent, fileSystem)
+        } catch (error: IllegalArgumentException) {
+            throw UsageError(error.message.orEmpty(), paramName = "file")
+        }
     }
 }

--- a/cli/src/commonMain/kotlin/cli/command/hook/install/Hook.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/install/Hook.kt
@@ -18,7 +18,7 @@ import com.github.ajalt.clikt.parameters.options.validate
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
-const val PREPARE_COMMIT_MSG_PATH = ".git/hooks/prepare-commit-msg"
+const val PREPARE_COMMIT_MSG_PATH = ".git/hooks/commit-msg"
 val prepareCommitMsg by lazy { PREPARE_COMMIT_MSG_PATH.toPath() }
 
 const val SHEBANG = "#!/usr/bin/env sh"
@@ -35,7 +35,7 @@ class Hook(
     help = """
         Install the 50-72 git hook in the current repository.
         
-        This is basically adding '$FORMAT_FILE_COMMAND' to the 'prepare-commit-msg' hook. If the
+        This is basically adding '$FORMAT_FILE_COMMAND' to the 'commit-msg' hook. If the
         hook file cli.cli.exists, it will be appended to, else a new one will be created.
     """.trimIndent()
 ) {

--- a/cli/src/commonTest/kotlin/cli/command/FormatMessageTest.kt
+++ b/cli/src/commonTest/kotlin/cli/command/FormatMessageTest.kt
@@ -8,7 +8,7 @@
 
 package cli.command
 
-import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.output.CliktConsole
 import kotlin.test.Test
@@ -28,15 +28,15 @@ class FormatMessageTest {
     }
 
     @Test
-    fun givenFormatReturnsThenPrintStdoutAndExit0() {
+    fun givenFormatReturnsThenPrintsStdoutAndExit0() {
         run("message")
         assertEquals("message\n", stdout)
         assertTrue(stderr.isEmpty())
     }
 
     @Test
-    fun givenFormatThrowsThenThrowUsageError() {
-        val error = assertFailsWith<UsageError> {
+    fun givenFormatThrowsThenInterruptsAndPrintsMessage() {
+        val error = assertFailsWith<PrintMessage> {
             run("message", formatThrows = true)
         }
         assertEquals(ERROR_MESSAGE, error.message)


### PR DESCRIPTION
Fix uncaught heading error in FormatFile

Don't print usage line on message errors. Was throwing the wrong exception.

Use commit-msg instead of prepare-commit-msg

>Unintended. commit-msg was always the correct one to use. See manual.