### PR TITLE
Fix :cli:buildLatestRelease

### DIFF
--- a/build-src/src/main/kotlin/multiplatform-native-app-release.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-native-app-release.gradle.kts
@@ -57,8 +57,11 @@ fun registerSymlinkTaskFor(target: KotlinTarget) =
             val executableDir = linkage.outputs.files.singleFile.toPath()
             executableDir.resolve("cli.kexe")
         }
-        outputs.file(symlinkFile)
         inputs.file(kexe)
+        outputs.file(symlinkFile)
+        outputs.upToDateWhen {
+            symlinkFile.asFile.exists()
+        }
         doLast {
             val linkPath = symlinkFile.asFile.toPath()
             Files.createSymbolicLink(linkPath, kexe.get())

--- a/formatter/src/commonTest/kotlin/FormatFullMessageTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatFullMessageTest.kt
@@ -113,6 +113,9 @@ class FormatFullMessageTest {
                 val actual = formatFullMessage(original)
                 assertEquals(expected, actual, "Message differs at case $i")
             } catch (error: Throwable) {
+                if (error is AssertionError) {
+                    throw error
+                }
                 throw AssertionError("Exception thrown at case $i: ${error.stackTraceToString()}")
             }
         }


### PR DESCRIPTION
Fix running :cli:buildLatestRelease twice.

It'd try to write a new symlink when one already existed. Fix by
enabling up-to-date checks.

Also, don't wrap AssertionErrors in miscMessages test, so that IntelliJ
will show the "Show difference" option for `assertEquals` errors.
