### PR TITLE
Add full Markdown support in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ below for instructions.
   <summary>
     Are there any other features? Can I use it in my own scripts?
   </summary>
+
   A manual `format` command is available so you can use it as part of your own scripts (in CI,
   for example). Here's the full help text:
 
@@ -121,8 +122,7 @@ Known to work out-of-the-box:
     Are markdown messages supported?
   </summary>
 
-  Markdown support is available with `50-72 format --markdown <message>` but still needs work. Currently,
-  the hook can't be installed with markdown enabled. Markdown will be fully supported in the browser extension.
+  Markdown is fully supported in the CLI and browser extension.
 
 </details>
 

--- a/build-src/src/main/kotlin/multiplatform-native-app-release.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-native-app-release.gradle.kts
@@ -57,10 +57,10 @@ fun registerSymlinkTaskFor(target: KotlinTarget) =
             val executableDir = linkage.outputs.files.singleFile.toPath()
             executableDir.resolve("cli.kexe")
         }
-        inputs.file(kexe)
+        inputs.property("kexePath", kexe.map { it.toString() })
         outputs.file(symlinkFile)
-        outputs.upToDateWhen {
-            symlinkFile.asFile.exists()
+        onlyIf {
+            !symlinkFile.asFile.exists()
         }
         doLast {
             val linkPath = symlinkFile.asFile.toPath()

--- a/cli/src/commonMain/kotlin/cli/command/FormatMessage.kt
+++ b/cli/src/commonMain/kotlin/cli/command/FormatMessage.kt
@@ -15,8 +15,6 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import formatFullMessage
 
-const val EXPERIMENTAL_MARKDOWN_WARNING = "WARNING: Markdown support is experimental"
-
 class FormatMessage(
     private val format: (message: String, isMarkdown: Boolean) -> String = ::formatFullMessage,
 ) : CliktCommand(
@@ -32,9 +30,6 @@ class FormatMessage(
     ).flag(default = false)
 
     override fun run() {
-        if (isMarkdown) {
-            echo(EXPERIMENTAL_MARKDOWN_WARNING, err = true)
-        }
         try {
             val formattedMessage = format(message, isMarkdown)
             echo(formattedMessage)

--- a/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
@@ -19,7 +19,7 @@ import formatFullMessage
 import okio.FileSystem
 import okio.Path.Companion.toPath
 
-private const val DEFAULT_GIT_MSG_FILE = ".git/EDIT_COMMITMSG"
+internal const val DEFAULT_GIT_MSG_FILE = ".git/EDIT_COMMITMSG"
 
 class FormatFile(
     private val fileSystem: FileSystem = defaultFileSystem,

--- a/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/FormatFile.kt
@@ -15,6 +15,8 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import formatFullMessage
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -26,7 +28,7 @@ class FormatFile(
     private val format: (message: String, isMarkdown: Boolean) -> String = ::formatFullMessage,
 ) : CliktCommand(
     name = "format-file",
-    help = "Format the git commit message file (or another file)".trimIndent()
+    help = "Format the git commit message file (or another file)"
 ) {
 
     private val messageFile by argument(
@@ -34,11 +36,16 @@ class FormatFile(
         help = "Path to the message file. Default is the standard git file, $DEFAULT_GIT_MSG_FILE"
     ).default(DEFAULT_GIT_MSG_FILE)
 
+    private val isMarkdown by option(
+        "--markdown",
+        help = "Set when message is in Markdown format. Default: false."
+    ).flag()
+
     override fun run() {
         try {
             val file = messageFile.toPath()
             val content = file.readText(fileSystem)
-            val formattedContent = format(content, false)
+            val formattedContent = format(content, isMarkdown)
             file.writeText(formattedContent, fileSystem)
         } catch (error: IllegalArgumentException) {
             throw PrintMessage(error.message.orEmpty(), error = true)

--- a/cli/src/commonMain/kotlin/cli/command/hook/install/Hook.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/install/Hook.kt
@@ -41,8 +41,13 @@ class Hook(
     """.trimIndent()
 ) {
 
-    private val install: Boolean by option().flag().validate { require(it || uninstall) }
-    private val uninstall: Boolean by option().flag().validate { require(it || install) }
+    private val install: Boolean by option(
+        help = "Install the hook"
+    ).flag().validate { require(it || uninstall) }
+
+    private val uninstall: Boolean by option(
+        help = "Uninstall the hook"
+    ).flag().validate { require(it || install) }
 
     private val markdownFormat by option(
         "--markdown",

--- a/cli/src/commonMain/kotlin/cli/command/hook/install/Hook.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/install/Hook.kt
@@ -19,10 +19,11 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 
 const val PREPARE_COMMIT_MSG_PATH = ".git/hooks/commit-msg"
-val prepareCommitMsg by lazy { PREPARE_COMMIT_MSG_PATH.toPath() }
+val prepareCommitMsg = PREPARE_COMMIT_MSG_PATH.toPath()
 
 const val SHEBANG = "#!/usr/bin/env sh"
-const val FORMAT_FILE_COMMAND = "50-72 format-file \"$1\""
+const val FORMAT_FILE_AS_PLAIN_TEXT_COMMAND = "50-72 format-file \"$1\""
+const val FORMAT_FILE_AS_MARKDOWN_COMMAND = "50-72 format-file --markdown \"$1\""
 
 const val NOT_A_GIT_DIR_MSG = "Current directory is not a git repository"
 
@@ -35,18 +36,23 @@ class Hook(
     help = """
         Install the 50-72 git hook in the current repository.
         
-        This is basically adding '$FORMAT_FILE_COMMAND' to the 'commit-msg' hook. If the
-        hook file cli.cli.exists, it will be appended to, else a new one will be created.
+        This is basically adding '$FORMAT_FILE_AS_PLAIN_TEXT_COMMAND' to the 'commit-msg' hook. If the
+        hook file exists, it will be appended to, else a new one will be created.
     """.trimIndent()
 ) {
 
     private val install: Boolean by option().flag().validate { require(it || uninstall) }
     private val uninstall: Boolean by option().flag().validate { require(it || install) }
 
+    private val markdownFormat by option(
+        "--markdown",
+        help = "Set if commit messages are written in the Markdown format. Default: false."
+    ).flag()
+
     override fun run() {
         checkGitDirExists()
         when {
-            install -> installAction()
+            install -> installAction(markdownFormat)
             uninstall -> uninstallAction()
             else -> error("Can't happen thanks to validate calls")
         }

--- a/cli/src/commonMain/kotlin/cli/command/hook/install/Install.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/install/Install.kt
@@ -4,7 +4,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */        
+ */
 
 package cli.command.hook.install
 
@@ -24,6 +24,12 @@ Please set permissions manually by running 'chmod' so that Git can run the hook:
     chmod 755 $PREPARE_COMMIT_MSG_PATH
 """
 
+const val MARKDOWN_COMMENT_CHAR_WARNING_MSG = """
+You must set 'git config core.commentChar' to something other than default '#',
+otherwise git will ignore Markdown headers, which also start with '#'.
+    git config core.commentChar ';'
+"""
+
 internal const val ALREADY_INSTALLED_MSG = "Already installed."
 
 class InstallActionImpl(
@@ -35,6 +41,9 @@ class InstallActionImpl(
         val command = commandForOption(markdownFormat)
         install(command)
         echo("Done! Please ensure 50-72 is in your PATH.")
+        if (markdownFormat) {
+            echo(MARKDOWN_COMMENT_CHAR_WARNING_MSG)
+        }
     }
 
     private fun install(command: String) {

--- a/cli/src/commonMain/kotlin/cli/command/hook/install/Install.kt
+++ b/cli/src/commonMain/kotlin/cli/command/hook/install/Install.kt
@@ -12,9 +12,10 @@ import cli.commons.*
 import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.output.TermUi.echo
 import okio.FileSystem
+import okio.Path
 
 fun interface InstallAction {
-    operator fun invoke()
+    operator fun invoke(markdownFormat: Boolean)
 }
 
 const val FAILED_TO_SET_PERMISSIONS_MSG = """
@@ -23,28 +24,48 @@ Please set permissions manually by running 'chmod' so that Git can run the hook:
     chmod 755 $PREPARE_COMMIT_MSG_PATH
 """
 
+internal const val ALREADY_INSTALLED_MSG = "Already installed."
+
 class InstallActionImpl(
     private val fileSystem: FileSystem = defaultFileSystem,
     private val permissionSetter: FilePermissionSetter = createFilePermissionSetter(),
 ) : InstallAction {
 
-    override fun invoke() {
-        prepareCommitMsg.run {
-            if (exists(fileSystem)) {
-                checkNotInstalled()
-                appendText("\n$FORMAT_FILE_COMMAND\n", fileSystem)
-            } else {
-                writeText("$SHEBANG\n\n$FORMAT_FILE_COMMAND\n", fileSystem)
-                setHookFilePermissions()
-            }
-        }
+    override fun invoke(markdownFormat: Boolean) {
+        val command = commandForOption(markdownFormat)
+        install(command)
         echo("Done! Please ensure 50-72 is in your PATH.")
     }
 
-    private fun checkNotInstalled() {
+    private fun install(command: String) {
+        prepareCommitMsg.run {
+            if (exists(fileSystem)) {
+                checkNotInstalledInHook()
+                appendCommand(command)
+            } else {
+                createWithCommand(command)
+            }
+        }
+    }
+
+    private fun commandForOption(markdownFormat: Boolean) = when {
+        markdownFormat -> FORMAT_FILE_AS_MARKDOWN_COMMAND
+        else -> FORMAT_FILE_AS_PLAIN_TEXT_COMMAND
+    }
+
+    private fun Path.appendCommand(command: String) {
+        appendText("\n$command\n", fileSystem)
+    }
+
+    private fun Path.createWithCommand(command: String) {
+        writeText("$SHEBANG\n\n$command\n", fileSystem)
+        setHookFilePermissions()
+    }
+
+    private fun checkNotInstalledInHook() {
         val installed = prepareCommitMsg.readLines(fileSystem).any { it.startsWith("50-72") }
         if (installed) {
-            throw PrintMessage("Already installed.")
+            throw PrintMessage(ALREADY_INSTALLED_MSG)
         }
     }
 

--- a/cli/src/commonTest/kotlin/cli/command/FormatMessageTest.kt
+++ b/cli/src/commonTest/kotlin/cli/command/FormatMessageTest.kt
@@ -70,13 +70,6 @@ class FormatMessageTest {
         assertEquals("message", formatArgs.message)
     }
 
-    @Test
-    fun warnsMarkdownIsExperimental() {
-        run("--markdown", "message")
-        assertEquals("$EXPERIMENTAL_MARKDOWN_WARNING\n", stderr)
-        assertEquals("message\n", stdout)
-    }
-
     @Suppress("UNCHECKED_CAST")
     private fun run(vararg args: String, formatThrows: Boolean = false) {
         FormatMessage(

--- a/cli/src/commonTest/kotlin/cli/command/hook/FormatFileTest.kt
+++ b/cli/src/commonTest/kotlin/cli/command/hook/FormatFileTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2022 Gabriel Feo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package cli.command.hook
 
 import cli.commons.readText

--- a/cli/src/commonTest/kotlin/cli/command/hook/FormatFileTest.kt
+++ b/cli/src/commonTest/kotlin/cli/command/hook/FormatFileTest.kt
@@ -1,0 +1,77 @@
+package cli.command.hook
+
+import cli.commons.readText
+import cli.commons.writeText
+import com.github.ajalt.clikt.core.PrintMessage
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+
+class FormatFileTest {
+
+    private val fileSystem = FakeFileSystem().apply {
+        emulateUnix()
+    }
+
+    @Test
+    fun givenMessageWithNoErrorsThenWritesFormattedMessage() {
+        val file = "./msgfile"
+        file.toPath().writeText("""Subject\n\nBody""", fileSystem)
+
+        run(file, formatReturnValue = "formatted msg")
+
+        assertEquals("formatted msg", file.toPath().readText(fileSystem))
+    }
+
+    @Test
+    fun givenFormatFailsThenFailsWithFormatErrorMessage() {
+        val file = "./msgfile"
+        file.toPath().writeText("any", fileSystem)
+
+        val error = assertFailsWith(PrintMessage::class) {
+            run(file, formatErrorMessage = "123")
+        }
+
+        assertEquals("123", error.message)
+    }
+
+    @Test
+    fun givenFormatFailsThenDoesntWriteToFile() {
+        val file = "./msgfile"
+        file.toPath().writeText("any", fileSystem)
+
+        assertFails {
+            run(file, formatErrorMessage = "any error")
+        }
+
+        assertEquals("any", file.toPath().readText(fileSystem))
+    }
+
+    @Test
+    fun givenNoMessageArgumentThenUsesGitCommitMsgFile() {
+        fileSystem.createDirectory(".git".toPath())
+        DEFAULT_GIT_MSG_FILE.toPath().writeText("msg", fileSystem)
+
+        run(formatReturnValue = "formatted msg")
+
+        assertEquals("formatted msg", DEFAULT_GIT_MSG_FILE.toPath().readText(fileSystem))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun run(
+        vararg args: String,
+        formatReturnValue: String = "",
+        formatErrorMessage: String? = null,
+    ) {
+        FormatFile(
+            fileSystem,
+            format = { _, _ ->
+                formatErrorMessage?.let { throw IllegalArgumentException(it) }
+                    ?: formatReturnValue
+            }
+        ).parse(args as Array<String>)
+    }
+}

--- a/cli/src/commonTest/kotlin/cli/command/hook/install/HookTest.kt
+++ b/cli/src/commonTest/kotlin/cli/command/hook/install/HookTest.kt
@@ -21,7 +21,7 @@ class HookTest {
 
     private val installAction = object : InstallAction {
         var called = false
-        override fun invoke() {
+        override fun invoke(markdownFormat: Boolean) {
             called = true
         }
     }

--- a/cli/src/commonTest/kotlin/cli/command/hook/install/UninstallActionTest.kt
+++ b/cli/src/commonTest/kotlin/cli/command/hook/install/UninstallActionTest.kt
@@ -35,7 +35,7 @@ class UninstallActionTest {
                 
                 echo
                 
-                $FORMAT_FILE_COMMAND
+                $FORMAT_FILE_AS_PLAIN_TEXT_COMMAND
                 
             """.trimIndent()
         )
@@ -56,12 +56,35 @@ class UninstallActionTest {
             """
                 $SHEBANG
                 
-                $FORMAT_FILE_COMMAND
+                $FORMAT_FILE_AS_PLAIN_TEXT_COMMAND
                 
             """.trimIndent()
         )
         action()
         assertHookDoesntExist()
+    }
+
+    @Test
+    fun givenHookExistsWithFormatAsMarkdownCommand_ThenRemovesCommand() {
+        givenHookExists(
+            """
+                $SHEBANG
+                
+                echo
+                
+                $FORMAT_FILE_AS_MARKDOWN_COMMAND
+                
+            """.trimIndent()
+        )
+        action()
+        assertHookEquals(
+            expected = """
+                $SHEBANG
+                
+                echo
+                
+            """.trimIndent()
+        )
     }
 
     private fun givenHookExists(content: String) {

--- a/formatter/src/commonMain/kotlin/info/CommitMessageInfo.kt
+++ b/formatter/src/commonMain/kotlin/info/CommitMessageInfo.kt
@@ -18,10 +18,14 @@ internal data class CommitMessageInfo(
         val match = Regex("^[^#\n]", MULTILINE).find(fullText)
         checkNotNull(match?.range?.first)
     }
+
     private val indexOfFirstMessageNewline =
         fullText.indexOf('\n', startIndex = indexOfFirstMessageChar)
 
-    val hasBody = indexOfFirstMessageNewline != -1
+    private val firstNewlineIsNewlineAtEof =
+        indexOfFirstMessageNewline == fullText.lastIndex
+
+    val hasBody = indexOfFirstMessageNewline != -1 && !firstNewlineIsNewlineAtEof
     val hasSubjectBodySeparator = hasBody && fullText[indexOfFirstMessageNewline + 1] == '\n'
     val subjectIsUpTo50Columns: Boolean = run {
         val firstMessageChar = indexOfFirstMessageChar

--- a/formatter/src/commonTest/kotlin/FormatMessageFileTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatMessageFileTest.kt
@@ -1,0 +1,9 @@
+import kotlin.test.Test
+
+class FormatMessageFileTest {
+
+    @Test
+    fun givenMessageFileWithNewlineAtEofThenDoesNotFail() {
+        formatFullMessage("$SINGLE_LINE_40\n")
+    }
+}

--- a/formatter/src/commonTest/kotlin/FormatMessageFileTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatMessageFileTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2022 Gabriel Feo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 import kotlin.test.Test
 
 class FormatMessageFileTest {


### PR DESCRIPTION
Support `--markdown` in CLI `format-file` and hook installer.

### Other changes

- Write tests on FormatFile command
- Add simple help text to hook flags
- Fix error with single-line message files

Error occurred in `CommitMessageInfo.hasSubjectBodySeparator`

```
Uncaught Kotlin exception: kotlin.ArrayIndexOutOfBoundsException
    at 0   cli.kexe                            0x000000010dc696e8 ThrowArrayIndexOutOfBoundsException + 88
    at 1   cli.kexe                            0x000000010dcbad3b kfun:#formatFullMessage(kotlin.String;kotlin.Boolean){}kotlin.String + 3179
    at 2   cli.kexe                            0x000000010dcfbcff kfun:cli.command.FormatMessage.$formatFullMessage$FUNCTION_REFERENCE$2.invoke#internal + 111
    at 3   cli.kexe                            0x000000010dcfbbb9 kfun:cli.command.FormatMessage#run(){} + 153
    at 4   cli.kexe                            0x000000010dce4898 kfun:com.github.ajalt.clikt.parsers.Parser.parse#internal + 15496
    at 5   cli.kexe                            0x000000010dce4905 kfun:com.github.ajalt.clikt.parsers.Parser.parse#internal + 15605
    at 6   cli.kexe                            0x000000010dd96787 Init_and_run_start + 4871
    at 7   cli.kexe                            0x000000010dd96d2e Konan_main + 14
    at 8   dyld                                0x000000011de354fe start + 462
fish: Job 1, '50-72 format --markdown 'someth…' terminated by signal SIGABRT (Abort)
```
