### PR TITLE
Use prefixes in release tags

### DIFF
--- a/.github/steps/parse-tag-version.sh
+++ b/.github/steps/parse-tag-version.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 tag_name="${1:?Tag name expected}"
 
-subject="$(git tag --list --format='%(contents:subject)' "$tag_name")"
-body="$(git tag --list --format='%(contents:body)' "$tag_name")"
-echo -e "$subject\n\n$body"
+if [[ "$tag_name" != */* ]] || [[ "$tag_name" == */*/* ]]; then
+  echo "Tag '$tag_name' must have exactly one prefix" >&2
+  exit 1
+fi
+
+# 'cli/v1.0.0' -> 'v1.0.0'
+echo "TAG_VERSION=${tag_name#*/}"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -8,7 +8,7 @@ name: 'CLI release'
 
 on:
   push:
-    tags: [v*]
+    tags: ['*/v*']
 
 defaults:
   run:
@@ -59,6 +59,8 @@ jobs:
         run: .github/steps/fetch-actual-tag.sh "$TAG_NAME"
       - name: Require annotated tag
         run: .github/steps/require-annotated-tag.sh "$TAG_NAME"
+      - name: Parse tag version
+        run: .github/steps/parse-tag-version.sh "$TAG_NAME" | tee -a "$GITHUB_ENV"
       - name: Parse tag message
         run: ./.github/steps/parse-tag-message.sh "$TAG_NAME" | tee ./tag_message
       - name: Download artifacts
@@ -79,6 +81,6 @@ jobs:
       - name: Update Homebrew formula
         run: |
           .github/steps/update-homebrew-formula.py \
-            --version "$TAG_NAME" \
+            --version "$TAG_VERSION" \
             --trigger-source "$ACTION_RUN_URL" \
             --assets artifacts/linux/* artifacts/macos/*


### PR DESCRIPTION
Used to separate releases of cli and browser-extension.