### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,50 @@
 # 50-72
 
+![CLI version shield][cli-version-shield]
+
 `50-72` is an utility to format your git commit messages to the [50/72 rule][rule-about]
-_automatically_.
-
-ℹ️ It's currently in a pre-release state but you can build from source (see below) ℹ️
-
-📣 A browser extension for formatting merge commits on GitHub and GitLab is coming soon 📣
-
-Install it in a local repository and it'll work from command-line `git` and any Git GUI or IDE you use Git with:
+_automatically_:
 
 ```shell
-# From the root dir of a repository:
-
-$ 50-72 hook --install
 $ git commit -m "Freestyle message
 > 
-> You don't have to worry about breaking lines yourself anymore. The quick brown fox jumps over the lazy dog. The quick
+> The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick
 > brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog."
 #  |
 #  |
-#  |  Gets committed as 
+#  |  Gets committed as
 #  V
 #
 # Freestyle message
 # 
-# You don't have to worry about breaking lines yourself anymore. The quick
-# brown fox jumps over the lazy dog. The quick brown fox jumps over the
-# lazy dog. The quick brown fox jumps over the lazy dog. The quick brown
-# fox jumps over the lazy dog.
+# The quick brown fox jumps over the lazy dog. The quick brown fox jumps
+# over the lazy dog. The quick brown fox jumps over the lazy dog. The
+# quick brown fox jumps over the lazy dog. The quick brown fox jumps over
+# the lazy dog.
 ```
 
-The hook must be installed per repository.
+📣 A browser extension for formatting merge commits on GitHub and GitLab is coming soon 📣
 
 ## Installing
 
-The easiest way to install on both macOS and Linux is with [Homebrew][brew]:
+ℹ️ It's stable, but still pre-release. File an [issue][new-issue] if you run into any problems
+
+On both macOS and Linux using [Homebrew][brew]:
 
 ```shell
 brew install gabrielfeo/50-72/cli
 ```
 
-This installs a pre-built binary from the [latest stable release][releases]. If you prefer to build from source, see
-below for instructions.
+Now that the 50-72 command is available, install it in a git repository:
+
+```shell
+$ 50-72 hook --install
+# Or, if you write messages in Markdown:
+$ 50-72 hook --install --markdown
+```
+
+This adds formatting to that repository's [git hooks][man-githook]. Once installed,
+it'll work from command-line `git` as well as any Git client you use with that repo.
 
 ## FAQ
 
@@ -82,13 +85,12 @@ hook         Install the 50-72 git hook in the current repository.
 
 <details>
   <summary>
-    How does it work?
+    Are existing git hooks deleted when I run <code>hook --install</code>?
   </summary>
 
-  `50-72 hook --install` simply adds to the
-  [`commit-msg` git hook][man-githook]
-  of the repository you run it from. If you already have such a hook in that repo, it will append to it,
-  otherwise it will create one. 
+  No. If you already have a [`commit-msg` git hook][man-githook] in the repo, `50-72 hook --install`
+  simply appends to it, preserving your existing commands. If there is no `commit-msg` hook, it
+  will create one.
 
 </details>
 
@@ -154,9 +156,19 @@ Known to work out-of-the-box:
     How can I uninstall command itself from my machine?
   </summary>
 
+  ⚠️ Make sure to run `50-72 hook --uninstall` in every repo before uninstalling the
+  command itself.
+
 ```shell
 brew uninstall fifty-seventy-two-cli
-brew untap gabrielfeo/50-72
+```
+
+  If you forget to uninstall the hook in some repository, you'll get a "command not found" error
+  when you try to commit because in that repo the hook still tries to format the message using `50-72`.
+  You can remove this leftover like this, from the root dir of the repo:
+
+```shell
+sed -I bak 's/^50-72 .*//' .git/hooks/commit-msg
 ```
 
 </details>
@@ -179,13 +191,22 @@ A symlink to the generated native executable will be created in `cli/build/relea
 
 ## Contributing
 
-Usage and bug descriptions are great first contributions. I'll treat bug reports as a gift.
+Usage and bug descriptions are great first contributions. PRs are also much welcome. Don't be afraid to ask for
+help.
 
-PRs are much welcome and I'll be happy to help you get started if you need. If you want to contribute code, please take
-a look at existing commits to follow current project patterns, and of course, follow the 50/72 rule! You can install
-the `50-72` hook in the `50-72` repo itself.
+### Contributing code
 
-The project is written in Kotlin Multiplatform compiling to native code and JavaScript.
+Before committing, please take a look at existing commits to follow current project patterns, and of course,
+follow the 50/72 rule! You can install the `50-72` hook in the `50-72` repo itself.
+
+The project is written in Kotlin Multiplatform compiling to native code (for the CLI) and JavaScript (for the
+browser extension). The build system is Gradle.
+
+- To run all tests, `./gradlew check`. Report is generated in `build/reports/` of each project. 
+- To build a CLI binary, see the "Building from source" section.
+- To build the CLI with debug symbols, `./gradlew :cli:linkDebugExecutable`. Outputs to `cli/build/bin/`.
+- To build the browser extension, `./gradlew :browser-extension:assemble`. Outputs to
+  `browser-extension/distributions/`. [Load it unpacked][load-unpacked] in Chrome to test it.
 
 [rule-about]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [brew]: https://brew.sh/
@@ -193,3 +214,5 @@ The project is written in Kotlin Multiplatform compiling to native code and Java
 [man-githook]: https://git-scm.com/docs/githooks#_commit_msg
 [issues]: https://github.com/gabrielfeo/50-72/issues
 [new-issue]: https://github.com/gabrielfeo/50-72/issues/new
+[load-unpacked]: https://developer.chrome.com/docs/extensions/mv3/getstarted/#unpacked
+[cli-version-shield]: https://img.shields.io/badge/dynamic/json?label=CLI&query=%24%5B%3F%28%2Fcli%5C%2F.%2A%2F.test%28%40.name%29%29%5D.name&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fgabrielfeo%2F50-72%2Ftags


### PR DESCRIPTION
- Simplify the intro
- Add a version badge of the latest CLI release
- Clarify in install section that hook install is per repo
- Add a warning about leftover hooks after uninstalling the command
- Expand Contributing section