### PR TITLE
Fix getting core.commentChar in CLI

### DIFF
--- a/cli/src/posixMain/kotlin/cli/commons/PosixCommandRunner.kt
+++ b/cli/src/posixMain/kotlin/cli/commons/PosixCommandRunner.kt
@@ -35,7 +35,10 @@ class PosixCommandRunner : CommandRunner {
                 append(input.toKString())
             }
         }
-        val status = pclose(stdoutFile)
+        val status = pclose(stdoutFile).let {
+            // To get the real status in the absence of WEXITSTATUS, divide by 256
+            it / 256
+        }
         return Exit(status, StdOut(stdout))
     }
 


### PR DESCRIPTION
In POSIX, to get the real status code WEXITSTATUS must be used with the
return of wait() (https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html).

Whenever `core.commentChar` was unset, `run` would return `256`
meaning a `1` exit status. Similarly, `127` would be returned as `32512`.