### PR TITLE
Fix formatting of parenthesized text

### DIFF
--- a/formatter/src/commonMain/kotlin/builder/MarkdownCommitMessageBuilder.kt
+++ b/formatter/src/commonMain/kotlin/builder/MarkdownCommitMessageBuilder.kt
@@ -100,7 +100,7 @@ private sealed interface Matcher {
         CodeSnippet("""```[^`]+```"""),
         HtmlElement("""<[^\/>]+\/>|<(\w+)[^\/>]*>[\s\S]*?<\/\1>"""),
         Link("""!?\[[^\]]+\][\[(][^\])]+[\])]"""),
-        PlainText("""(?:\w+\S*)+"""),
+        PlainText("""(?:\S*\w+\S*)+"""),
         WordSpacing(" +"),
         SingleLineBreak("""\n"""),
         Punctuation("""[^\w\s]"""),

--- a/formatter/src/commonTest/kotlin/FormatFullMessageTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatFullMessageTest.kt
@@ -96,6 +96,12 @@ class FormatFullMessageTest {
     }
 
     @Test
+    fun reformatsMovingParenthesesAlongsideWords() {
+        val reformatted = formatFullMessage(MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN)
+        assertEquals(MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN_FIXED, reformatted)
+    }
+
+    @Test
     fun stripsCommentsWithDefaultGitCommentChar() {
         val reformatted = formatFullMessage(MESSAGE_73_WITH_COMMENT_CHAR_HASH)
         assertEquals(MESSAGE_73_WITH_COMMENT_CHAR_HASH_FIXED, reformatted)

--- a/formatter/src/commonTest/kotlin/FormatMarkdownFullMessageTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatMarkdownFullMessageTest.kt
@@ -41,4 +41,14 @@ class FormatMarkdownFullMessageTest {
         )
         assertEquals(MD_MSG_WITH_COMMENT_CHAR_SEMICOLON_STRIPPED, reformatted)
     }
+
+    @Test
+    fun reformatsMovingParenthesesAlongsideWords() {
+        val reformatted = formatFullMessage(
+            MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN,
+            isMarkdown = true,
+            commentChar = ';',
+        )
+        assertEquals(MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN_FIXED, reformatted)
+    }
 }

--- a/formatter/src/commonTest/kotlin/Messages.kt
+++ b/formatter/src/commonTest/kotlin/Messages.kt
@@ -180,6 +180,37 @@ const val SQUASH_MESSAGE_SUBJECT_50_BODY_72_STRIPPED = """a
 
 b"""
 
+const val MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN = """Subject
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo (foo foo)
+foo
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo fo (foo)
+foo
+
+In POSIX, to get the real status code WEXITSTATUS must be used with the
+return of wait() (https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html).
+
+In POSIX, to get the real status code WEXITSTATUS must be used with the
+return of wait()(https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html).
+"""
+
+const val MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN_FIXED = """Subject
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo
+(foo foo) foo
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo fo
+(foo) foo
+
+In POSIX, to get the real status code WEXITSTATUS must be used with the
+return of wait()
+(https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html).
+
+In POSIX, to get the real status code WEXITSTATUS must be used with the
+return of
+wait()(https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html)."""
+
 val miscMessages = mapOf(
     //0------------------------------------------------------------------
     """


### PR DESCRIPTION
Previously, would move first word of parenthesized text without the
opening parentheses. Occurred in Markdown formatter only.