### PR TITLE
Optimize Markdown formatter regex matching

### DIFF
--- a/build-src/src/main/kotlin/multiplatform-opt-in.gradle.kts
+++ b/build-src/src/main/kotlin/multiplatform-opt-in.gradle.kts
@@ -7,14 +7,9 @@
  */
 
 plugins {
-    id("multiplatform-native-library")
-    id("multiplatform-js-browser-library")
-    id("multiplatform-opt-in")
+    id("multiplatform")
 }
 
-group = "com.gabrielfeo"
-version = "1.0-SNAPSHOT"
-
-dependencies {
-    commonTestImplementation(kotlin("test"))
+kotlin.sourceSets.configureEach {
+    languageSettings.optIn("kotlin.RequiresOptIn")
 }

--- a/formatter/src/commonMain/kotlin/builder/MarkdownCommitMessageBuilder.kt
+++ b/formatter/src/commonMain/kotlin/builder/MarkdownCommitMessageBuilder.kt
@@ -59,7 +59,7 @@ internal data class MarkdownCommitMessageBuilder(
         matchers: Array<Matcher>,
     ): Pair<Matcher, String> {
         for (matcher in matchers) {
-            val match = matcher.matchAtStart(body, currentPosition) ?: continue
+            val match = matcher.matchAt(body, currentPosition) ?: continue
             return matcher to match
         }
         val currentPositionSnippet = body.substring(currentPosition, currentPosition + 10)
@@ -71,10 +71,9 @@ private sealed interface Matcher {
 
     val pattern: String
 
-    fun matchAtStart(string: String, startIndex: Int): String? {
-        val result = Regex(pattern).find(string, startIndex)
-        return result?.takeIf { it.range.first == startIndex }?.value
-    }
+    @OptIn(ExperimentalStdlibApi::class)
+    fun matchAt(string: String, index: Int): String? =
+        Regex(pattern).matchAt(string, index)?.value
 
     data class Comment(
         val commentChar: Char,


### PR DESCRIPTION
Make matching stop early if no match at startIndex. Previous
implementation was inefficient. Matching would proceed to find
any match in the string, only for it to be discarded if not at
at startIndex. `matchAt` achieves the same behavior in all
platforms.

### Performance

In native, reduces mean time of formatting a big body with --markdown
in ~83%. Using hyperfine with 1 warmup, 10 runs:

```
Message: "subject\n\nfoo foo foo..." (single paragraph, 2000-char body)

Benchmark 1: 50-72 format "..."
  Time (mean ± σ):      25.6 ms ±   3.7 ms    [User: 12.0 ms, System: 9.1 ms]
  Range (min … max):    21.4 ms …  31.4 ms    10 runs

Benchmark 2: 50-72 format --markdown "..."
  Time (mean ± σ):      2.994 s ±  0.024 s    [User: 2.926 s, System: 0.055 s]
  Range (min … max):    2.966 s …  3.045 s    10 runs

Benchmark 3: ./new-version-release format --markdown "..."
  Time (mean ± σ):     561.4 ms ±   5.9 ms    [User: 537.9 ms, System: 17.5 ms]
  Range (min … max):   554.3 ms … 573.0 ms    10 runs
```

### Experimental usage

`matchAt` is experimental. If API changes break this usage in the
future, an alternative might be:

- for native (PCRE): the A flag or the \G anchor (tested)
- for JVM: the \G anchor (tested)
- for JS: the y flag and/or changing RegExp.lastIndex