### PR TITLE
Fix errors due to punctuation in Markdown

### DIFF
--- a/formatter/src/commonMain/kotlin/builder/MarkdownCommitMessageBuilder.kt
+++ b/formatter/src/commonMain/kotlin/builder/MarkdownCommitMessageBuilder.kt
@@ -42,7 +42,8 @@ internal data class MarkdownCommitMessageBuilder(
                 HtmlElement,
                 Quote,
                 Heading,
-                Punctuation -> sequence.appendRaw(match)
+                EndPunctuation -> sequence.appendRaw(match)
+                StandalonePunctuation -> sequence.append(match.trim())
                 ParagraphBreak -> sequence.breakParagraph()
                 is Comment,
                 WordSpacing,
@@ -95,13 +96,14 @@ private sealed interface Matcher {
         Quote(""">[^\n]+(?:\n>[^\n]+)*"""),
         Table("""\|.*\|(?:\n\|.*\|){2,}"""),
         BulletListItem("""[ \t]*- [^\n]+(?:\n[^\n]+|[ \t]*- [^\n]+)*"""),
-        NumberedListItem("""[\t ]*[\d\w]+\. [^\n]+(?:\n[^\n]+|\n[\t ]*[\d\w]+\. [^\n]+)*"""),
+        NumberedListItem("""[\t ]*\d{1,9}\. [^\n]+(?:\n[^\n]+|\n[\t ]*\d{1,9}\. [^\n]+)*"""),
         CodeSnippet("""```[^`]+```"""),
         HtmlElement("""<[^\/>]+\/>|<(\w+)[^\/>]*>[\s\S]*?<\/\1>"""),
         Link("""!?\[[^\]]+\][\[(][^\])]+[\])]"""),
         PlainText("""(?:\S*\w+\S*)+"""),
+        StandalonePunctuation("""[\t ]+[^\w\s]+(?=\s)"""),
         WordSpacing(" +"),
         SingleLineBreak("""\n"""),
-        Punctuation("""[^\w\s]"""),
+        EndPunctuation("""\s*[^\w\s](?=$|\n\n)"""),
     }
 }

--- a/formatter/src/commonTest/kotlin/FormatMarkdownFullMessageTest.kt
+++ b/formatter/src/commonTest/kotlin/FormatMarkdownFullMessageTest.kt
@@ -51,4 +51,14 @@ class FormatMarkdownFullMessageTest {
         )
         assertEquals(MESSAGE_WITH_PARENTHESIZED_WORDS_ON_72_COLUMN_FIXED, reformatted)
     }
+
+    @Test
+    fun reformatsCorrectlyWithMiscPunctuation() {
+        val reformatted = formatFullMessage(
+            MD_BODY_WITH_MISC_PUNCTUATION,
+            isMarkdown = true,
+            commentChar = ';',
+        )
+        assertEquals(MD_BODY_WITH_MISC_PUNCTUATION_FIXED, reformatted)
+    }
 }

--- a/formatter/src/commonTest/kotlin/MarkdownMessages.kt
+++ b/formatter/src/commonTest/kotlin/MarkdownMessages.kt
@@ -342,3 +342,37 @@ foo foo
 
 foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo
 foo foo foo"""
+
+const val MD_BODY_WITH_MISC_PUNCTUATION = """[JIRA-1] (subject): bla bla. Bla (bla...) or 'bla'
+
+bla. 1bla `bla`; bla\bla bla/bla bla+bla bla+ bla++ --bla -bla -b. "bla"? bla@bla bla?! US${'$'} 40.00 | 2¢ {£4} ~3%
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo a && b
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo a || b
+
+*alsm bla.
+
+bla bla ( bla )
+
+alsm bla?
+
+
+"""
+
+const val MD_BODY_WITH_MISC_PUNCTUATION_FIXED = """[JIRA-1] (subject): bla bla. Bla (bla...) or 'bla'
+
+bla. 1bla `bla`; bla\bla bla/bla bla+bla bla+ bla++ --bla -bla -b.
+"bla"? bla@bla bla?! US${'$'} 40.00 | 2¢ {£4} ~3%
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo a
+&& b
+
+foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo a
+|| b
+
+*alsm bla.
+
+bla bla ( bla )
+
+alsm bla?"""


### PR DESCRIPTION
Fix misparsing of text + full stop as list item

Prevent space trimming on standalone punctuation